### PR TITLE
Removing adding the ansible_user to the docker group

### DIFF
--- a/playbooks/app_install/roles/docker_install/tasks/main.yml
+++ b/playbooks/app_install/roles/docker_install/tasks/main.yml
@@ -98,12 +98,6 @@
     name: docker
     state: present
 
-- name: "Create user {{ ansible_user }} on {{ inventory_hostname }} and add to docker group"
-  ansible.builtin.user:
-    name: "{{ ansible_user }}"
-    groups: docker
-    append: yes
-
 - name: Start and Enable the Docker service
   ansible.builtin.service:
     name: docker


### PR DESCRIPTION
This was breaking the BES that ansible_user is undefined, and ansible is assuming root regardless.