### PR TITLE
Moving the docker data dir to /jenkins/docker

### DIFF
--- a/playbooks/app_install/roles/docker_install/tasks/main.yml
+++ b/playbooks/app_install/roles/docker_install/tasks/main.yml
@@ -43,13 +43,14 @@
     state: directory
     mode: 750
 
-- name: Touch /etc/docker/daemon.json if it doesnt exist or update mod time
-  ansible.builtin.file:
+- name: Configure Docker to use custom data directory
+  lineinfile:
     path: /etc/docker/daemon.json
-    state: touch
-    mode: 740
-    modification_time: preserve
-    access_time: preserve
+    create: yes
+    line: |
+      {
+        "data-root": "{{ docker_data_dir }}"
+      }
 
 - name: Download docker_arch_path to the /tmp/ dir using no auth and no proxy
   ansible.builtin.get_url:

--- a/playbooks/app_install/roles/docker_install/vars/main.yml
+++ b/playbooks/app_install/roles/docker_install/vars/main.yml
@@ -4,7 +4,8 @@ docker_version: 24.0.6
 # Whether to retrieve from artifactory to push to target
 # or push from the controller to the target when set local
 docker_rpm_src: artifactory
-artifact_path:  "https://engci-maven-master.cisco.com/artifactory/cmsp-sapphire-development-group/up-sac-utils/jenkins/v1/docker-ce-{{ docker_version | default('24.0.6') }}-rpms.tar.gz"
+docker_data_dir: "/jenkins/docker"
+artifact_path: "https://engci-maven-master.cisco.com/artifactory/cmsp-sapphire-development-group/up-sac-utils/jenkins/v1/docker-ce-{{ docker_version | default('24.0.6') }}-rpms.tar.gz"
 docker_rpm_filename: "docker-ce-{{ docker_version | default('24.0.6') }}-rpms.tar.gz"
 # Which packages should be cleared out before installing docker
 package_removals:


### PR DESCRIPTION
I think the BES worker is running out of space so moving the docker data dir to the /jenkins/dir as /jenkins has 100GB allocated to it.